### PR TITLE
Remove errant `?` and improve `SignalNumber` type definition

### DIFF
--- a/src/main.d.ts
+++ b/src/main.d.ts
@@ -134,7 +134,7 @@ export interface Signal {
 /**
  * Object whose keys are signal names and values are signal objects.
  */
-export declare const signalsByName: { [SignalNameType in SignalName]?: Signal }
+export declare const signalsByName: { [SignalNameType in SignalName]: Signal }
 
 /**
  * Object whose keys are signal numbers and values are signal objects.

--- a/src/main.d.ts
+++ b/src/main.d.ts
@@ -87,7 +87,69 @@ export type SignalName =
  * While most number are cross-platform, some are different between different
  * OS.
  */
-export type SignalNumber = number
+export type SignalNumber =
+  | 1
+  | 2
+  | 3
+  | 4
+  | 5
+  | 6
+  | 7
+  | 8
+  | 9
+  | 10
+  | 11
+  | 12
+  | 13
+  | 14
+  | 15
+  | 16
+  | 17
+  | 18
+  | 19
+  | 20
+  | 21
+  | 22
+  | 23
+  | 24
+  | 25
+  | 26
+  | 27
+  | 28
+  | 29
+  | 30
+  | 31
+  | 34
+  | 35
+  | 36
+  | 37
+  | 38
+  | 39
+  | 40
+  | 41
+  | 42
+  | 43
+  | 44
+  | 45
+  | 46
+  | 47
+  | 48
+  | 49
+  | 50
+  | 51
+  | 52
+  | 53
+  | 54
+  | 55
+  | 56
+  | 57
+  | 58
+  | 59
+  | 60
+  | 61
+  | 62
+  | 63
+  | 64
 
 export interface Signal {
   /**
@@ -139,4 +201,6 @@ export declare const signalsByName: { [SignalNameType in SignalName]: Signal }
 /**
  * Object whose keys are signal numbers and values are signal objects.
  */
-export declare const signalsByNumber: { [signalNumber: SignalNumber]: Signal }
+export declare const signalsByNumber: {
+  [SignalNumberType in SignalNumber]: Signal
+}

--- a/src/main.test-d.ts
+++ b/src/main.test-d.ts
@@ -20,14 +20,14 @@ expectType<boolean>(sigintSignal.forced)
 expectType<SignalStandard>(sigintSignal.standard)
 
 const sigintOne = signalsByNumber[1]
-expectType<Signal | undefined>(sigintOne)
-expectType<SignalName>(sigintOne!.name)
-expectType<SignalNumber>(sigintOne!.number)
-expectType<string>(sigintOne!.description)
-expectType<boolean>(sigintOne!.supported)
-expectType<SignalAction>(sigintOne!.action)
-expectType<boolean>(sigintOne!.forced)
-expectType<SignalStandard>(sigintOne!.standard)
+expectType<Signal>(sigintOne)
+expectType<SignalName>(sigintOne.name)
+expectType<SignalNumber>(sigintOne.number)
+expectType<string>(sigintOne.description)
+expectType<boolean>(sigintOne.supported)
+expectType<SignalAction>(sigintOne.action)
+expectType<boolean>(sigintOne.forced)
+expectType<SignalStandard>(sigintOne.standard)
 
 expectAssignable<SignalName>('SIGINT')
 expectAssignable<SignalName>('SIGRT1')
@@ -42,6 +42,8 @@ expectNotAssignable<SignalName>('SIGRT32')
 
 expectAssignable<SignalNumber>(1)
 expectNotAssignable<SignalNumber>('1')
+// eslint-disable-next-line @typescript-eslint/no-magic-numbers
+expectNotAssignable<SignalNumber>(999)
 
 expectAssignable<SignalAction>('terminate')
 expectAssignable<SignalAction>('core')

--- a/src/main.test-d.ts
+++ b/src/main.test-d.ts
@@ -10,14 +10,14 @@ import {
 import { expectAssignable, expectNotAssignable, expectType } from 'tsd'
 
 const sigintSignal = signalsByName.SIGINT
-expectType<Signal | undefined>(sigintSignal)
-expectType<SignalName>(sigintSignal!.name)
-expectType<SignalNumber>(sigintSignal!.number)
-expectType<string>(sigintSignal!.description)
-expectType<boolean>(sigintSignal!.supported)
-expectType<SignalAction>(sigintSignal!.action)
-expectType<boolean>(sigintSignal!.forced)
-expectType<SignalStandard>(sigintSignal!.standard)
+expectType<Signal>(sigintSignal)
+expectType<SignalName>(sigintSignal.name)
+expectType<SignalNumber>(sigintSignal.number)
+expectType<string>(sigintSignal.description)
+expectType<boolean>(sigintSignal.supported)
+expectType<SignalAction>(sigintSignal.action)
+expectType<boolean>(sigintSignal.forced)
+expectType<SignalStandard>(sigintSignal.standard)
 
 const sigintOne = signalsByNumber[1]
 expectType<Signal | undefined>(sigintOne)


### PR DESCRIPTION
**Which problem is this pull request solving?**

Typescript would complain that `signalsByName` could potentially return `undefined`. This is not true but was caused by an errant `?` at

https://github.com/ehmicky/human-signals/blob/0f9928856970ba55d64e887ffb1246dce2d3df55/src/main.d.ts#L137

**List other issues or pull requests related to this problem**

Fixes #23 

**Describe the solution you've chosen**

See commit messages

**Describe alternatives you've considered**

Explicitly defining `SignalNumber` values could potentially cause lint complaints in existing code. An option would be not to include the commit that does this.

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have added tests (we are enforcing 100% test coverage).
- [ ] I have added documentation in the `README.md`, the `docs` directory (if
      any) and the `examples` directory (if any).
- [x] The status checks are successful (continuous integration). Those can be
      seen below.
